### PR TITLE
Point assets to root

### DIFF
--- a/service-worker.js
+++ b/service-worker.js
@@ -1,11 +1,12 @@
-var cacheVersion = 'v1.3';
+var cacheVersion = 'v1.4';
 
 filesToCache = [
-  'index.html',
-  'about.html',
-  'css/main.css',
-  'js/main.js',
-  'img/gear.png'
+  '/',
+  '/index.html',
+  '/about.html',
+  '/css/main.css',
+  '/js/main.js',
+  '/img/gear.png'
 ]
 
 self.addEventListener('install', function (e) {


### PR DESCRIPTION
When I visit https://ascott1.github.io/sw-demo/, only `service-worker.js` is cached .

<img width="533" alt="screen shot 2016-06-05 at 7 07 19 pm" src="https://cloud.githubusercontent.com/assets/1060248/15808870/c48e3d7a-2b50-11e6-8898-e082c3ba9100.png">

The [Service Workers](https://github.com/ascott1/ethical-web-dev/blob/master/web-apps-that-work-everywhere/05-offline.md#service-workers) section shows code that's different from what's in the demo. This PR updates the demo to match what's in the book.
